### PR TITLE
fix(security)!: unsafe org-confirm-babel-evaluate set to nil

### DIFF
--- a/notebook.el
+++ b/notebook.el
@@ -181,7 +181,6 @@
   (add-to-list 'font-lock-extra-managed-props 'display)
   (setq font-lock-keywords-case-fold-search t)
   (setq org-image-actual-width `( ,(truncate (* (frame-pixel-width) 0.85))))
-  (setq org-confirm-babel-evaluate nil)
   (setq org-startup-with-inline-images t)
   (org-redisplay-inline-images)
   (org-indent-mode)

--- a/notebook.org
+++ b/notebook.org
@@ -228,3 +228,7 @@ if filename:
 return ""
 #+end_src
 
+* COMMENT Local Variables
+Local Variables:
+org-confirm-babel-evaluate: nil
+End:


### PR DESCRIPTION
The org-confirm-babel-evaluate is an unsafe variable to set to nil as a global value, especially if the mode sets it without any warning or notice.

This commit removes this unsafe setup as a security measure. Now the users can, if they wish so, set this value in their init file, or add a hook to notebook-mode, or (most secure way to do it) set it as a file-local variable.

The notebook.org document implements the last solution as an example.

BREAKING CHANGE: org-confirm-babel-evaluate setup now left to user.
Signed-off-by: Alexandre Martos <contact@amartos.fr>