### PR TITLE
refactor: use built-in functions for loading and defining aliases

### DIFF
--- a/notebook.el
+++ b/notebook.el
@@ -165,9 +165,7 @@
   (require 'ob-python)
   (require 'oc-csl))
 
-(defun notebook-run ()
-  (interactive)
-  (org-babel-execute-buffer))
+(defalias 'notebook-run 'org-babel-execute-buffer)
 
 (defun notebook-export-html ()
   (interactive)

--- a/notebook.el
+++ b/notebook.el
@@ -189,6 +189,7 @@
   (svg-tag-mode -1)
   (remove-hook 'org-babel-after-execute-hook 'org-redisplay-inline-images))
 
+;;;###autoload
 (define-minor-mode notebook-mode
   "Minor mode for graphical tag as rounded box."
   :group 'notebook

--- a/notebook.el
+++ b/notebook.el
@@ -156,9 +156,7 @@
   (org-ctrl-c-ctrl-c)
   (org-redisplay-inline-images))
 
-(defun notebook-call-at-point ()
-  (interactive)
-  (org-ctrl-c-ctrl-c))
+(defalias 'notebook-call-at-point 'org-ctrl-c-ctrl-c)
 
 (defun notebook-setup ()
   (interactive)

--- a/notebook.el
+++ b/notebook.el
@@ -167,9 +167,7 @@
 
 (defalias 'notebook-run 'org-babel-execute-buffer)
 
-(defun notebook-export-html ()
-  (interactive)
-  (org-html-export-to-html))
+(defalias 'notebook-export-html 'org-html-export-to-html)
 
 (defun notebook-mode-on ()
   "Activate SVG tag mode."


### PR DESCRIPTION
Some functions are defined as interactive aliases, but of already interactive functions, and they do not use the `defalias` function.

Moreover, the main mode function is not autoloaded.

These commits fix these issues.