### PR TITLE
feat: add customization options for the module

### DIFF
--- a/notebook.el
+++ b/notebook.el
@@ -44,6 +44,10 @@
 (require 'org)
 (require 'svg-tag-mode)
 
+(defgroup notebook nil
+  "Customization options for `notebook-mode'."
+  :group 'org)
+
 (setq svg-tag-tags
       '(
         ;; Inline code

--- a/notebook.el
+++ b/notebook.el
@@ -48,7 +48,7 @@
   "Customization options for `notebook-mode'."
   :group 'org)
 
-(setq svg-tag-tags
+(defcustom notebook-tags
       '(
         ;; Inline code
         ;; --------------------------------------------------------------------
@@ -152,8 +152,12 @@
         ("^#\\+label:" .     ((lambda (tag) (svg-tag-make "LABEL"
                                             :face 'org-meta-line))))
         ("^#\\+results:"  .  ((lambda (tag) (svg-tag-make "RESULTS"
-                                            :face 'org-meta-line))))))
-
+                                            :face 'org-meta-line)))))
+  "The `notebook-mode' tags alist.
+This alist is the `notebook-mode' specific tags list.  It follows the
+same definition pattern as the `svg-tag-tags' alist (to which
+`notebook-tags' is added)."
+  :group 'notebook)
 
 (defun notebook-run-at-point ()
   (interactive)
@@ -187,6 +191,7 @@
   (setq org-image-actual-width `( ,(truncate (* (frame-pixel-width) 0.85))))
   (setq org-confirm-babel-evaluate nil)
   (setq org-startup-with-inline-images t)
+  (mapc #'(lambda (tag) (add-to-list 'svg-tag-tags tag)) notebook-tags)
   (org-redisplay-inline-images)
   (org-indent-mode)
   (org-hide-block-all)

--- a/notebook.el
+++ b/notebook.el
@@ -159,6 +159,11 @@ same definition pattern as the `svg-tag-tags' alist (to which
 `notebook-tags' is added)."
   :group 'notebook)
 
+(defcustom notebook-hide-blocks t
+  "Default visibility of org blocks in `notebook-mode'.
+If non-nil, the org blocks are hidden when the mode is turned on."
+  :group 'notebook)
+
 (defun notebook-run-at-point ()
   (interactive)
   (org-ctrl-c-ctrl-c)
@@ -194,7 +199,7 @@ same definition pattern as the `svg-tag-tags' alist (to which
   (mapc #'(lambda (tag) (add-to-list 'svg-tag-tags tag)) notebook-tags)
   (org-redisplay-inline-images)
   (org-indent-mode)
-  (org-hide-block-all)
+  (if notebook-hide-blocks (org-hide-block-all))
   (add-hook 'org-babel-after-execute-hook 'org-redisplay-inline-images)
   (svg-tag-mode 1))
 
@@ -202,6 +207,7 @@ same definition pattern as the `svg-tag-tags' alist (to which
   "Deactivate SVG tag mode."
 
   (svg-tag-mode -1)
+  (if notebook-hide-blocks (org-hide-block-all))
   (remove-hook 'org-babel-after-execute-hook 'org-redisplay-inline-images))
 
 (define-minor-mode notebook-mode

--- a/notebook.el
+++ b/notebook.el
@@ -48,6 +48,11 @@
   "Customization options for `notebook-mode'."
   :group 'org)
 
+(defcustom notebook-babel-python-command
+  "/opt/anaconda3/bin/python"
+  "Python interpreter's path."
+  :group 'notebook)
+
 (defcustom notebook-tags
       '(
         ;; Inline code
@@ -181,7 +186,7 @@ If non-nil, the org blocks are hidden when the mode is turned on."
 (defun notebook-setup ()
   (interactive)
   (setq org-cite-csl-styles-dir ".")
-  (setq org-babel-python-command "/opt/anaconda3/bin/python")
+  (setq org-babel-python-command notebook-babel-python-command)
   (require 'ob-python)
   (require 'oc-csl))
 

--- a/notebook.el
+++ b/notebook.el
@@ -159,6 +159,11 @@ same definition pattern as the `svg-tag-tags' alist (to which
 `notebook-tags' is added)."
   :group 'notebook)
 
+(defcustom notebook-indent t
+  "Default document indentation.
+If non-nil, `org-indent' is called when the mode is turned on."
+  :group 'notebook)
+
 (defcustom notebook-hide-blocks t
   "Default visibility of org blocks in `notebook-mode'.
 If non-nil, the org blocks are hidden when the mode is turned on."
@@ -198,7 +203,7 @@ If non-nil, the org blocks are hidden when the mode is turned on."
   (setq org-startup-with-inline-images t)
   (mapc #'(lambda (tag) (add-to-list 'svg-tag-tags tag)) notebook-tags)
   (org-redisplay-inline-images)
-  (org-indent-mode)
+  (if notebook-indent (org-indent-mode))
   (if notebook-hide-blocks (org-hide-block-all))
   (add-hook 'org-babel-after-execute-hook 'org-redisplay-inline-images)
   (svg-tag-mode 1))
@@ -207,6 +212,7 @@ If non-nil, the org blocks are hidden when the mode is turned on."
   "Deactivate SVG tag mode."
 
   (svg-tag-mode -1)
+  (if notebook-indent (org-indent-mode -1))
   (if notebook-hide-blocks (org-hide-block-all))
   (remove-hook 'org-babel-after-execute-hook 'org-redisplay-inline-images))
 

--- a/notebook.el
+++ b/notebook.el
@@ -53,6 +53,11 @@
   "Python interpreter's path."
   :group 'notebook)
 
+(defcustom notebook-cite-csl-styles-dir
+  "."
+  "CSL styles citations' directory."
+  :group 'notebook)
+
 (defcustom notebook-tags
       '(
         ;; Inline code
@@ -185,7 +190,7 @@ If non-nil, the org blocks are hidden when the mode is turned on."
 
 (defun notebook-setup ()
   (interactive)
-  (setq org-cite-csl-styles-dir ".")
+  (setq org-cite-csl-styles-dir notebook-cite-csl-styles-dir)
   (setq org-babel-python-command notebook-babel-python-command)
   (require 'ob-python)
   (require 'oc-csl))

--- a/notebook.el
+++ b/notebook.el
@@ -169,6 +169,10 @@ same definition pattern as the `svg-tag-tags' alist (to which
 `notebook-tags' is added)."
   :group 'notebook)
 
+(defcustom notebook-font-lock-case-insensitive t
+  "Make the keywords fontification case insensitive if non-nil."
+  :group 'notebook)
+
 (defcustom notebook-indent t
   "Default document indentation.
 If non-nil, `org-indent' is called when the mode is turned on."
@@ -207,7 +211,7 @@ If non-nil, the org blocks are hidden when the mode is turned on."
   "Activate SVG tag mode."
 
   (add-to-list 'font-lock-extra-managed-props 'display)
-  (setq font-lock-keywords-case-fold-search t)
+  (setq font-lock-keywords-case-fold-search notebook-font-lock-case-insensitive)
   (setq org-image-actual-width `( ,(truncate (* (frame-pixel-width) 0.85))))
   (setq org-confirm-babel-evaluate nil)
   (setq org-startup-with-inline-images t)


### PR DESCRIPTION
Multiple variables throughout the module are hardcoded, but are suited for user customizations. These commits set those variables in the already-defined `notebook` group (which is here defined as a child of the `org` group).